### PR TITLE
Reduce logging output in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ after_success:
   - tar -cf ../IndexDirectory.tar IndexDirectory/
   - cd ../
   - pv IndexDirectory.tar | gzip -v9 > IndexDirectory.tar.gz
+  - echo 'Resulting tarball is' $(du -h IndexDirectory.tar.gz | cut -f 1) '; should be 900M at minimum'
+  - if [ $(du -k IndexDirectory.tar.gz | cut -f 1) -le $((1024 * 900)) ]; then echo "Resulting tarball is too small; build failed"; exit 1; fi
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,15 @@ install:
   # Build CLAVIN
   - cd CLAVIN/
   - mvn compile
-  - cd ../  
+  - cd ../ 
+  - mv ./logback.xml ./CLAVIN/target/classes/logback.xml
 
 script:
 
-  # Create the Lucene index
+  # Create the Lucene index, using travis_wait bc log level is set to warning (not info). Travis will
+  # shut down a build if there's no logging output for 10 minutes, and this step can take 30+ min.
   - cd CLAVIN/
-  - mvn exec:java -Dexec.mainClass="com.bericotech.clavin.index.IndexDirectoryBuilder"
+  - travis_wait 45 mvn exec:java -Dexec.mainClass="com.bericotech.clavin.index.IndexDirectoryBuilder"
   - cd ../
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ git push --tags
 ```
 
 ...and wait for [![Build Status](https://travis-ci.org/mediacloud/clavin-build-geonames-index.svg?branch=develop)](https://travis-ci.org/mediacloud/clavin-build-geonames-index) to complete. Upon completion, the prebuilt index will end up in [releases](https://github.com/mediacloud/clavin-build-geonames-index/releases).
+
+Note that this repository pins the `CLAVIN` submodule at [this commit](https://github.com/Novetta/CLAVIN/tree/c38832ff63e3118427162faf30b87d9e4f2b201b) from 2016. The `logback.xml` file in the root directory here
+patches that project during the build, via `.travis.yml`, to decrease its logging verbosity. If you want to pin `CLAVIN` to a more recent commit, make sure you review the project to see whether the directory structure has changed and, consequently, whether the `mv ./logback.xml` command in `.travis.yml` needs to be adjusted.

--- a/logback.xml
+++ b/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- patch for clavin submodule, whose logging is so verbose when level="info" that it exceeds
+       travis's max log length and the build fails. we mv this file into the submodule during
+       the build via .travis.yml -->
+  <root level="warn">
+    <appender-ref ref="STDOUT" />
+  </root>

--- a/logback.xml
+++ b/logback.xml
@@ -14,3 +14,5 @@
   <root level="warn">
     <appender-ref ref="STDOUT" />
   </root>
+
+</configuration>


### PR DESCRIPTION
Patch to change log level in `CLAVIN` build from `info` to `warn`. Travis builds otherwise [fail](https://travis-ci.org/github/mediacloud/clavin-build-geonames-index) because the `CLAVIN` build, under normal circumstances, is [extremely verbose](https://github.com/mediacloud/backend/issues/741#issuecomment-730401323) (specifically, there are a number of lines in the insanely long text file it downloads from geonames that can't be parsed correctly, and it logs each of those instances). Travis has a ceiling for log output of 4MB, after which it terminates the build, which is what otherwise bites us here.

Relates to https://github.com/mediacloud/backend/issues/741

